### PR TITLE
Issues/fix socrates GitHub link

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -88,6 +88,7 @@ projects[wysiwyg_filter][version] = "1.6-rc9"
 ; Themes
 projects[bootstrap][version] = "3.15"
 projects[ember][version] = "2.0-alpha4"
+projects[socrates][type] = "theme"
 projects[socrates][download][type] = git
 projects[socrates][download][url] = https://github.com/linnovate/socrates.git
 projects[socrates][download][branch] = 7.x-1.x


### PR DESCRIPTION
In drupal-org.make must set type of the github project. Otherwise it downloaded into modules folder.