### PR TITLE
README Doc Clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OpenideaL includes tools for the website managers which allow them to identify *
 OI is based on Drupal, and therefore it is modular, and allows growth and adaptation to the organization’s specific needs. These adaptations may include a unique design, polls and surveys, interfacing with external applications or adapting the interface to a range of devices ans apis.
 
 ## Prerequisites:
-OpenideaL relies heavily upon [Drupal](https://www.drupal.org/) and is subject to its system requirements. OpenIdeaL will require several additional packages and tools from the Drupal dependencies pre-installed to build OpenIdeaL. For the best experience, we recommend ensuring that you have satisfied the [Drupal System Requirements](https://www.drupal.org/docs/system-requirements) before moving forward.
+Since OpenideaL relies on [Drupal](https://www.drupal.org/) and is subject to its system requirements, it is recommended ensuring that you have satisfied the [Drupal System Requirements](https://www.drupal.org/docs/system-requirements) before moving forward.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,7 @@ OpenideaL includes tools for the website managers which allow them to identify *
 OI is based on Drupal, and therefore it is modular, and allows growth and adaptation to the organization’s specific needs. These adaptations may include a unique design, polls and surveys, interfacing with external applications or adapting the interface to a range of devices ans apis.
 
 ## Prerequisites:
-OpenideaL will require several PHP packages pre-installed to build your installation. For the best experience, we recommend installing the following packages prior to building OpenideaL:
-* php  
-* php-xml  
-* php(version)-gd  **Note: replace (version) with the actual version of PHP installed, e.g. "php7.3-gd"**  
-
-1. To install pre-requisites (Linux with apt package manager):  
-`sudo apt install php php-xml`  
-2. Once this is done, find your version of php:  
-`php --version`  
-3. Install gd for your version of php (In this example, I use PHP v7.3):  
-`sudo apt install php7.3-gd`
+OpenideaL relies heavily upon [Drupal](https://www.drupal.org/) and is subject to its system requirements. OpenIdeaL will require several additional packages and tools from the Drupal dependencies pre-installed to build OpenIdeaL. For the best experience, we recommend ensuring that you have satisfied the [Drupal System Requirements](https://www.drupal.org/docs/system-requirements) before moving forward.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ OpenideaL includes tools for the website managers which allow them to identify *
 
 OI is based on Drupal, and therefore it is modular, and allows growth and adaptation to the organization’s specific needs. These adaptations may include a unique design, polls and surveys, interfacing with external applications or adapting the interface to a range of devices ans apis.
 
+## Prerequisites:
+OpenideaL will require several PHP packages pre-installed to build your installation. For the best experience, we recommend installing the following packages prior to building OpenideaL:
+* php  
+* php-xml  
+* php(version)-gd  **Note: replace (version) with the actual version of PHP installed, e.g. "php7.3-gd"**  
+
+1. To install pre-requisites (Linux with apt package manager):  
+`sudo apt install php php-xml`  
+2. Once this is done, find your version of php:  
+`php --version`  
+3. Install gd for your version of php (In this example, I use PHP v7.3):  
+`sudo apt install php7.3-gd`
+
 ## Build
 
 OpenideaL is super easy to install. The following composer command will install the full codebase, together with all the required dependencies and libraries:


### PR DESCRIPTION
On a fresh machine, I found that not all PHP dependencies were fully resolved prior to building, after running "composer create-project linnovate/openideal-composer openideal" as per the doc. I don't have the expertise to add these dependencies to the build process, but this temporary doc update will shorten the google-aided learning curve for new users until these dependencies are resolved in the build process, if that's possible.