### PR TITLE
Missing ckeditor plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,6 +169,30 @@
                     "type": "zip"
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/fakeobjects",
+                "version": "4.17.2",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.17.2.zip",
+                    "type": "zip"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/link",
+                "version": "4.17.2",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/link/releases/link_4.17.2.zip",
+                    "type": "zip"
+                }
+            }
         }
     ],
     "require": {
@@ -180,6 +204,8 @@
         "ckeditor/embed": "4.17.2",
         "ckeditor/embedbase": "4.17.2",
         "ckeditor/embedsemantic": "4.17.2",
+        "ckeditor/fakeobjects": "4.17.2",
+        "ckeditor/link": "4.17.2",
         "ckeditor/mentions": "4.17.2",
         "ckeditor/notification": "4.17.2",
         "ckeditor/notificationaggregator": "4.17.2",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/mentions",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/mentions/releases/mentions_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/mentions/releases/mentions_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -30,10 +30,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/autocomplete",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/autocomplete/releases/autocomplete_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/autocomplete/releases/autocomplete_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -42,10 +42,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/textmatch",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/textmatch/releases/textmatch_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/textmatch/releases/textmatch_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -54,10 +54,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/textwatcher",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/textwatcher/releases/textwatcher_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/textwatcher/releases/textwatcher_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -66,10 +66,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/ajax",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/ajax/releases/ajax_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/ajax/releases/ajax_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -78,10 +78,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/xml",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/xml/releases/xml_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/xml/releases/xml_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -90,10 +90,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/embed",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/embed/releases/embed_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/embed/releases/embed_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -102,10 +102,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/embedsemantic",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/embedsemantic/releases/embedsemantic_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/embedsemantic/releases/embedsemantic_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -114,10 +114,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/embedbase",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/embedbase/releases/embedbase_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/embedbase/releases/embedbase_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -126,10 +126,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/autoembed",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/autoembed/releases/autoembed_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/autoembed/releases/autoembed_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -138,10 +138,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/autolink",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/autolink/releases/autolink_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/autolink/releases/autolink_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -150,10 +150,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/notification",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/notification/releases/notification_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/notification/releases/notification_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -162,10 +162,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor/notificationaggregator",
-                "version": "4.14.1",
+                "version": "4.17.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/notificationaggregator/releases/notificationaggregator_4.14.1.zip",
+                    "url": "https://download.ckeditor.com/notificationaggregator/releases/notificationaggregator_4.17.2.zip",
                     "type": "zip"
                 }
             }
@@ -173,19 +173,19 @@
     ],
     "require": {
         "bower-asset/c3": "^0.7.20",
-        "ckeditor/ajax": "4.14.1",
-        "ckeditor/autocomplete": "4.14.1",
-        "ckeditor/autoembed": "4.14.1",
-        "ckeditor/autolink": "4.14.1",
-        "ckeditor/embed": "4.14.1",
-        "ckeditor/embedbase": "4.14.1",
-        "ckeditor/embedsemantic": "4.14.1",
-        "ckeditor/mentions": "4.14.1",
-        "ckeditor/notification": "4.14.1",
-        "ckeditor/notificationaggregator": "4.14.1",
-        "ckeditor/textmatch": "4.14.1",
-        "ckeditor/textwatcher": "4.14.1",
-        "ckeditor/xml": "4.14.1",
+        "ckeditor/ajax": "4.17.2",
+        "ckeditor/autocomplete": "4.17.2",
+        "ckeditor/autoembed": "4.17.2",
+        "ckeditor/autolink": "4.17.2",
+        "ckeditor/embed": "4.17.2",
+        "ckeditor/embedbase": "4.17.2",
+        "ckeditor/embedsemantic": "4.17.2",
+        "ckeditor/mentions": "4.17.2",
+        "ckeditor/notification": "4.17.2",
+        "ckeditor/notificationaggregator": "4.17.2",
+        "ckeditor/textmatch": "4.17.2",
+        "ckeditor/textwatcher": "4.17.2",
+        "ckeditor/xml": "4.17.2",
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.2",


### PR DESCRIPTION
Adding 2 missing CKEditor plugins required by newer version of ckeditor_media_embed Drupal module.
And upgrade all CKeditor plugins to 4.17.2